### PR TITLE
Add fallback to PangaeaDataset.get_geo() 

### DIFF
--- a/pyleotups/utils/PangaeaStudy.py
+++ b/pyleotups/utils/PangaeaStudy.py
@@ -391,7 +391,7 @@ class PangaeaStudy:
                     }
                 )
                 
-            return pd.DataFrame(rows)
+        return pd.DataFrame(rows)
 
     # ------------------------------------------------------------------
     # Publications

--- a/pyleotups/utils/PangaeaStudy.py
+++ b/pyleotups/utils/PangaeaStudy.py
@@ -367,7 +367,31 @@ class PangaeaStudy:
                     "Elevation": ev.elevation,
                 }
             )
-        return pd.DataFrame(rows)
+        
+        # --------------------------------------------------
+        # Fallback: dataset-level geometryextent
+        # --------------------------------------------------
+        if not rows:
+
+            geo = getattr(self._panobj, "geometryextent", None)
+
+            if geo:
+
+                rows.append(
+                    {
+                        "StudyID": self.study_id,
+                        "SiteID": None,
+                        "SiteName": None,
+                        "LocationName": None,
+                        "MinLatitude": ( float(geo["southBoundLatitude"]) if geo.get("southBoundLatitude") is not None else None),
+                        "MaxLatitude": ( float(geo["northBoundLatitude"]) if geo.get("northBoundLatitude") is not None else None),
+                        "MinLongitude": ( float(geo["westBoundLongitude"]) if geo.get("westBoundLongitude") is not None else None),
+                        "MaxLongitude": ( float(geo["eastBoundLongitude"]) if geo.get("eastBoundLongitude") is not None else None),
+                        "Elevation": None,
+                    }
+                )
+                
+            return pd.DataFrame(rows)
 
     # ------------------------------------------------------------------
     # Publications


### PR DESCRIPTION
## Summary

Adds a fallback mechanism in `get_geo()` to use dataset-level `geometryextent` metadata when event-level geographic information is unavailable.

## Changes

* Preserve existing event-based geographic extraction logic
* Add fallback to `PanDataSet.geometryextent`
* Generate geographic bounds from:

  * `westBoundLongitude`
  * `eastBoundLongitude`
  * `southBoundLatitude`
  * `northBoundLatitude`
* Skip empty event geometries safely

## Motivation

Some PANGAEA datasets do not populate `events` with geographic coordinates but still provide valid spatial coverage through `geometryextent`. This update improves robustness and geographic metadata coverage across datasets.
