### PR TITLE
Fix get_data() dropping files when a DataTableID has multiple URLs

### DIFF
--- a/pyleotups/core/NOAADataset.py
+++ b/pyleotups/core/NOAADataset.py
@@ -48,7 +48,8 @@ class NOAADataset(BaseDataset):
         Attributes are set to their default empty values.
         """
         self.studies = {}               # NOAAStudyId -> NOAAStudy instance
-        self.data_table_index = {}      # dataTableID -> dict with study, site, paleo_data
+        self.data_table_index = {}      # dataTableID -> dict with study, site, paleo_data (last one wins)
+        self.data_table_index_all = {}  # dataTableID -> list of ALL matching dicts (handles duplicate IDs)
         self.file_url_to_datatable = {} # file_url -> dataTableID
         # self.last_timing = {}
         self.logger = logging.getLogger("pyleotups.NOAADataset")
@@ -57,22 +58,58 @@ class NOAADataset(BaseDataset):
     def _reindex(self):
         """Rebuild secondary indexes from `self.studies`."""
         self.data_table_index.clear()
+        self.data_table_index_all.clear()
         self.file_url_to_datatable.clear()
 
         for study in self.studies.values():
             for site in study.sites:
                 for paleo in site.paleo_data:
-                    # map datatable -> study/site/paleo
-                    self.data_table_index[paleo.datatable_id] = {
+                    # map datatable -> study/site/paleo (single entry; last one wins on collision)
+                    mapping = {
                         "study_id": study.study_id,
                         "site_id": site.site_id,
                         "paleo_data": paleo,
                     }
+                    self.data_table_index[paleo.datatable_id] = mapping
+                    # map datatable -> ALL study/site/paleo entries sharing this ID, so
+                    # get_data() can still open every one of them even when the ID collides.
+                    self.data_table_index_all.setdefault(paleo.datatable_id, []).append(mapping)
                     # map file_url -> datatable
                     for f in paleo.files:
                         url = f.get("fileUrl")
                         if url:
                             self.file_url_to_datatable[url] = paleo.datatable_id
+
+    def _check_duplicate_datatable_ids(self, context=""):
+        """
+        Warn about DataTableIDs shared by more than one (Study, Site) pair.
+
+        NOAA DataTableIDs are expected to be unique, but when they are not,
+        `self.data_table_index` (keyed by DataTableID) can only point to one of
+        the colliding entries. `get_data()` uses `self.data_table_index_all`
+        instead so it still opens every colliding entry's files; this method
+        only surfaces the collision to the user via a log warning.
+
+        Parameters
+        ----------
+        context : str, optional
+            Short prefix identifying the calling method, used in the log message.
+
+        Returns
+        -------
+        dict
+            Mapping of duplicated DataTableID -> list of (StudyID, SiteID) pairs.
+        """
+        duplicates = {
+            dt_id: [(m["study_id"], m["site_id"]) for m in mappings]
+            for dt_id, mappings in self.data_table_index_all.items()
+            if len(mappings) > 1
+        }
+        for dt_id, locs in duplicates.items():
+            log.warning(
+                f"{context}Duplicate DataTableID '{dt_id}' found across multiple Study/Site pairs {locs}."
+            )
+        return duplicates
 
     def __add__(self, other):
         if not isinstance(other, NOAADataset):
@@ -523,6 +560,7 @@ class NOAADataset(BaseDataset):
         
         self.studies.clear()
         self.data_table_index.clear()
+        self.data_table_index_all.clear()
         self.file_url_to_datatable.clear()
 
         for study_data in tqdm(data.get('study', []), desc="Parsing NOAA studies"):
@@ -531,11 +569,13 @@ class NOAADataset(BaseDataset):
 
             for site in study_obj.sites:
                 for paleo in site.paleo_data:
-                    self.data_table_index[paleo.datatable_id] = {
+                    mapping = {
                         'study_id': study_obj.study_id,
                         'site_id': site.site_id,
                         'paleo_data': paleo
                     }
+                    self.data_table_index[paleo.datatable_id] = mapping
+                    self.data_table_index_all.setdefault(paleo.datatable_id, []).append(mapping)
                     for file_obj in paleo.files:
                         file_url = file_obj.get('fileUrl')
                         if file_url:
@@ -680,6 +720,8 @@ class NOAADataset(BaseDataset):
             df = ds.get_tables()
             df.head()
         """
+        self._check_duplicate_datatable_ids(context="get_tables(): ")
+
         records = []
 
         for study in self.studies.values():
@@ -924,21 +966,178 @@ class NOAADataset(BaseDataset):
         return df.set_index("DataTableID")
     
 
+    def _rank_file_priority(self, file_obj):
+        """
+        Rank a NOAA file entry by how "easy" it is expected to be to parse.
+
+        Lower rank is attempted first. Order follows the priority requested for
+        `get_data`: NOAA structured (templated) .txt -> Original Contributed .txt
+        -> .csv -> web page / directory listing -> anything else (e.g. proprietary
+        binary formats like .crn/.rwl/.fhx/.lpd, which pyleotups cannot parse).
+
+        Parameters
+        ----------
+        file_obj : dict
+            A raw `dataFile` entry, expected to have a ``fileUrl`` and optionally
+            a ``urlDescription``.
+
+        Returns
+        -------
+        int
+            Priority rank (0 = easiest/first, 4 = last resort).
+        """
+        url = (file_obj.get('fileUrl') or '').strip()
+        desc = (file_obj.get('urlDescription') or '').lower()
+        name = url.rsplit('/', 1)[-1]
+        file_type = name.rsplit('.', 1)[-1].lower() if '.' in name else ''
+
+        if file_type == 'txt':
+            return 0 if ('noaa' in desc or 'template' in desc) else 1
+        if file_type == 'csv':
+            return 2
+        if file_type in self._PROPRIETARY_TYPES:
+            return 4
+        # No extension (directory index) or an .html/.htm page -> treat as a web page.
+        return 3
+
+    @staticmethod
+    def _extract_links_from_html(base_url, html_text):
+        """
+        Extract absolute hyperlinks from an HTML page (e.g. a NOAA directory listing).
+
+        Only links whose target filename has an extension are kept, so directory
+        "Parent Directory" / sibling-folder links are skipped and recursion into
+        another folder page cannot loop indefinitely.
+
+        Parameters
+        ----------
+        base_url : str
+            The (already-redirect-resolved) URL the HTML was fetched from, used to
+            resolve relative hrefs.
+        html_text : str
+            Raw HTML content of the page.
+
+        Returns
+        -------
+        list of str
+            Deduplicated, absolute candidate file URLs discovered on the page.
+        """
+        from html.parser import HTMLParser
+        from urllib.parse import urljoin, urlparse
+
+        hrefs = []
+
+        class _LinkParser(HTMLParser):
+            def handle_starttag(self, tag, attrs):
+                if tag.lower() == 'a':
+                    for attr, value in attrs:
+                        if attr.lower() == 'href' and value:
+                            hrefs.append(value)
+
+        _LinkParser().feed(html_text)
+
+        base = base_url if base_url.endswith('/') else base_url + '/'
+
+        seen = set()
+        links = []
+        for href in hrefs:
+            href = href.strip()
+            if not href or href in ('.', '..') or href.startswith('#'):
+                continue
+
+            parsed = urlparse(href)
+            if parsed.scheme and parsed.scheme not in ('http', 'https'):
+                continue  # skip mailto:, javascript:, etc.
+
+            absolute = urljoin(base, href)
+            if absolute in seen:
+                continue
+
+            # Skip links back into a (sub)folder — only keep actual files.
+            name = absolute.rsplit('/', 1)[-1]
+            if '.' not in name:
+                continue
+
+            seen.add(absolute)
+            links.append(absolute)
+
+        return links
+
+    def _attach_metadata(self, df, mapping):
+        """Attach NOAAStudyId/StudyName metadata to a parsed DataFrame, if available."""
+        df.attrs['NOAAStudyId'] = mapping.get('study_id')
+        study_obj = self.studies.get(mapping.get('study_id'), {})
+        df.attrs['StudyName'] = study_obj.metadata.get("studyName") if hasattr(study_obj, 'metadata') else None
+        return df
+
+    def _process_csv_file(self, file_url, mapping=None):
+        """Fetch and parse a .csv data file into a single-item list of DataFrames."""
+        try:
+            df = pd.read_csv(file_url)
+        except Exception as e:
+            raise RuntimeError(f"Failed to read CSV file from '{file_url}': {e}")
+
+        if mapping:
+            df = self._attach_metadata(df, mapping)
+        return [df]
+
+    def _process_folder_page(self, file_url, html_text, mapping=None):
+        """
+        Treat `file_url` as a web page/directory-index rather than a data file:
+        extract hyperlinks from the page and attempt every candidate file (easiest
+        first, same priority order as `get_data`), collecting a DataFrame for each
+        one that parses rather than stopping at the first success.
+        """
+        candidate_urls = self._extract_links_from_html(file_url, html_text)
+        if not candidate_urls:
+            raise UnsupportedFileTypeError(
+                f"'{file_url}' is a web page/folder with no discoverable data file links."
+            )
+
+        ranked_urls = sorted(candidate_urls, key=lambda u: self._rank_file_priority({'fileUrl': u}))
+
+        results = []
+        last_error = None
+        for url in ranked_urls:
+            try:
+                results.extend(self._process_file(url, mapping))
+            except Exception as e:
+                last_error = e
+                log.warning(f"Could not parse linked file '{url}' discovered on page '{file_url}': {e}")
+
+        if not results:
+            raise UnsupportedFileTypeError(
+                f"None of the {len(ranked_urls)} link(s) discovered on '{file_url}' could be parsed. "
+                f"Last error: {last_error}"
+            )
+        return results
+
     def _process_file(self, file_url, mapping=None):
         """
-        Process a single file URL: detect parser, parse the file, and attach metadata.
+        Process a single file URL: detect its type, parse it, and attach metadata.
+
+        Supports NOAA .txt files (structured/NOAA-templated or contributed),
+        .csv files, and web pages/directory listings (whose linked files are
+        discovered and attempted in turn). Proprietary formats (.crn/.rwl/.fhx/.lpd)
+        and any other extension are rejected.
         """
         if not file_url:
             raise ValueError("File URL is missing.")
 
-        file_type = file_url.split('.')[-1].lower()
+        name = file_url.rsplit('/', 1)[-1]
+        file_type = name.rsplit('.', 1)[-1].lower() if '.' in name else ''
+
         if file_type in self._PROPRIETARY_TYPES:
             raise UnsupportedFileTypeError(
-                f"pyleotups works with .txt files only. File type '{file_type}' is proprietary."
+                f"pyleotups works with .txt/.csv files only. File type '{file_type}' is proprietary."
             )
-        if file_type != 'txt':
+
+        if file_type == 'csv':
+            return self._process_csv_file(file_url, mapping)
+
+        if file_type not in ('', 'txt', 'html', 'htm'):
             raise UnsupportedFileTypeError(
-                f"Invalid file type '{file_type}'. Only .txt files are supported."
+                f"Invalid file type '{file_type}'. Only .txt, .csv files and web-page/folder links are supported."
             )
 
         # Step 1: Detect parser type by reading initial lines
@@ -991,10 +1190,24 @@ class NOAADataset(BaseDataset):
         try:
             response = requests.get(file_url)
             response.raise_for_status()
-            lines = response.text.splitlines()
-            parser_type = detect_parser_type(lines)
         except Exception as e:
             raise RuntimeError(f"Failed to read file from '{file_url}': {e}")
+
+        # An .html/.htm link, or an extension-less link (e.g. a NOAA directory
+        # listing), may actually be a web page rather than a data file. Detect
+        # this from the response and, if so, hand off to the folder-page handler
+        # (using the redirect-resolved URL so relative links resolve correctly).
+        content_type = response.headers.get('Content-Type', '').lower()
+        looks_like_html = 'html' in content_type or file_type in ('html', 'htm')
+        if not looks_like_html and file_type == '':
+            sniff = response.text.lstrip()[:300].lower()
+            looks_like_html = sniff.startswith('<!doctype html') or sniff.startswith('<html')
+
+        if looks_like_html:
+            return self._process_folder_page(response.url, response.text, mapping)
+
+        lines = response.text.splitlines()
+        parser_type = detect_parser_type(lines)
 
         # Step 2: Use the appropriate parser
         if parser_type == "standard":
@@ -1012,12 +1225,6 @@ class NOAADataset(BaseDataset):
             raise RuntimeError(f"Error while parsing file {file_url}: {e}")
 
         # Step 3: Attach metadata
-        def attach_metadata(df, mapping):
-            df.attrs['NOAAStudyId'] = mapping.get('study_id')
-            study_obj = self.studies.get(mapping.get('study_id'), {})
-            df.attrs['StudyName'] = study_obj.metadata.get("studyName") if hasattr(study_obj, 'metadata') else None
-            return df
-
         results = []
         to_process = []
 
@@ -1041,7 +1248,7 @@ class NOAADataset(BaseDataset):
         # Now `to_process` contains only the DataFrames we want
         for df in to_process:
             if mapping:
-                df = attach_metadata(df, mapping)
+                df = self._attach_metadata(df, mapping)
             results.append(df)
 
         return results
@@ -1051,6 +1258,21 @@ class NOAADataset(BaseDataset):
         """
         Fetch external data for given dataTableIDs or file URLs, perform validations,
         and attach study and site metadata.
+
+        A single DataTableID can be associated with several files of different
+        formats (e.g. a NOAA-templated .txt file, the original contributed .txt,
+        a .csv, or a web page/folder listing links to all of them) — and these
+        files do not always hold the same data in different formats (e.g. a tree-ring
+        DataTableID may bundle separate "Raw Measurements" and "Chronology" files).
+        Every available file for a DataTableID is therefore attempted — starting
+        with the one expected to be easiest to parse (NOAA structured .txt, then
+        Original Contributed .txt, then .csv, then web page/folder links) — and a
+        DataFrame is kept for every file that parses successfully; a file that
+        fails to parse is logged and skipped rather than aborting the others.
+
+        If the same DataTableID is (unexpectedly) associated with more than one
+        Study/Site, a warning is logged and files from *every* matching Study/Site
+        are attempted, so none of them are silently dropped.
 
         Parameters
         ----------
@@ -1067,10 +1289,11 @@ class NOAADataset(BaseDataset):
         Raises
         ------
         ValueError
-            For missing parent study mapping, missing file URL, or proprietary/unsupported file types.
+            For missing parent study mapping, missing file URL, or if none of the
+            available files for a DataTableID could be parsed.
         Exception
             Propagates any exceptions raised by the parser.
-        
+
         Examples
         --------
 
@@ -1086,17 +1309,56 @@ class NOAADataset(BaseDataset):
 
         # Process based on dataTableIDs.
         if dataTableIDs:
+            self._check_duplicate_datatable_ids(context="get_data(): ")
+
             dataTableIDs = assert_list(dataTableIDs)
             for dt_id in dataTableIDs:
 
-                mapping = self.data_table_index.get(dt_id)
-                if not mapping:
+                mappings = self.data_table_index_all.get(dt_id)
+                if not mappings:
                     raise ValueError(f"No parent study mapping found for Data Table ID '{dt_id}'. "
                                      "Please perform a search using this DataTableID or provide a specific file URL.")
-                file_url = mapping['paleo_data'].file_url
-                if not file_url:
-                    raise ValueError(f"File URL for Data Table ID '{dt_id}' is missing. Cannot fetch data.")
-                dfs.extend(self._process_file(file_url, mapping))
+
+                any_success = False
+                attempted_urls = []
+                last_error = None
+
+                for mapping in mappings:
+                    files = mapping['paleo_data'].files
+                    if not files:
+                        log.warning(
+                            f"get_data(): No files found for Data Table ID '{dt_id}' under Study "
+                            f"'{mapping['study_id']}' / Site '{mapping['site_id']}'; skipping."
+                        )
+                        continue
+
+                    # Attempt EVERY file for this DataTableID — easiest first (NOAA
+                    # structured .txt -> Original Contributed .txt -> .csv -> web
+                    # page/folder link) — since different files under the same ID
+                    # can hold genuinely different data (e.g. tree-ring "Chronology"
+                    # vs "Raw Measurements"), not just alternate formats of the same
+                    # table. A file failing to parse does not stop the others.
+                    for file_obj in sorted(files, key=self._rank_file_priority):
+                        url = file_obj.get('fileUrl')
+                        if not url:
+                            continue
+                        attempted_urls.append(url)
+                        try:
+                            dfs.extend(self._process_file(url, mapping))
+                            any_success = True
+                        except Exception as e:
+                            last_error = e
+                            log.warning(
+                                f"get_data(): Could not use file '{url}' for Data Table ID '{dt_id}' "
+                                f"(Study '{mapping['study_id']}' / Site '{mapping['site_id']}'): {e}. "
+                                "Trying next available file for this Data Table ID."
+                            )
+
+                if not any_success:
+                    raise ValueError(
+                        f"None of the {len(attempted_urls)} file(s) available for Data Table ID '{dt_id}' "
+                        f"could be parsed. URLs attempted: {attempted_urls}. Last error: {last_error}"
+                    )
             return dfs
 
         # Process based on file_urls provided directly.

--- a/pyleotups/tests/test_NOAADataset.py
+++ b/pyleotups/tests/test_NOAADataset.py
@@ -383,7 +383,7 @@ class TestNOAADatasetGetDataMocked:
 
     # --- Test t05: file with unsupported extension ---
     def test_get_data_t05_unsupported_file_type_raises(self):
-        with pytest.raises(UnsupportedFileTypeError, match="Only .txt files are supported"):
+        with pytest.raises(UnsupportedFileTypeError, match="Invalid file type 'xlsx'"):
             self.ds._process_file("https://example.com/data.xlsx")
 
     # --- Test t06: unparsable file structure ---
@@ -523,6 +523,159 @@ class TestNOAADatasetAddBinary:
             "duplicate" in record.message.lower() and "study" in record.message.lower() and "18315" in record.message
             for record in caplog.records
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: multiple files per DataTableID -> easiest-first priority + fallback
+# ---------------------------------------------------------------------------
+
+class TestNOAADatasetMultiFilePriority:
+
+    def setup_method(self):
+        self.ds = NOAADataset()
+        self.mock_data = get_mock_study_response()
+        self.ds._parse_response(self.mock_data, limit=100)
+        self.dt_id = next(iter(self.ds.data_table_index_all))
+        self.mapping = self.ds.data_table_index[self.dt_id]
+
+        # Give this DataTableID two files of different formats, deliberately
+        # listed with the "harder" one first to prove ordering isn't positional.
+        self.mapping["paleo_data"].files = [
+            {"fileUrl": "https://example.com/original.csv", "urlDescription": "Alternate Format Data"},
+            {"fileUrl": "https://example.com/data-noaa.txt", "urlDescription": "NOAA Template File"},
+        ]
+
+    def test_rank_prefers_noaa_txt_over_csv(self):
+        """_rank_file_priority ranks a NOAA-templated .txt ahead of a .csv."""
+        files = self.mapping["paleo_data"].files
+        ranked = sorted(files, key=self.ds._rank_file_priority)
+        assert ranked[0]["fileUrl"].endswith("-noaa.txt")
+        assert ranked[1]["fileUrl"].endswith(".csv")
+
+    @patch.object(NOAADataset, "_process_file")
+    def test_get_data_tries_next_file_when_easiest_fails(self, mock_process):
+        """If the highest-priority file fails to parse, get_data falls back to the next one."""
+        def side_effect(url, mapping=None):
+            if url.endswith("-noaa.txt"):
+                raise RuntimeError("boom")
+            return [pd.DataFrame({"x": [1]})]
+
+        mock_process.side_effect = side_effect
+
+        result = self.ds.get_data(dataTableIDs=[self.dt_id])
+        assert len(result) == 1
+
+        called_urls = [c.args[0] for c in mock_process.call_args_list]
+        assert called_urls[0].endswith("-noaa.txt")  # easiest attempted first
+        assert called_urls[1].endswith(".csv")        # fallback attempted second
+
+    @patch.object(NOAADataset, "_process_file")
+    def test_get_data_raises_when_all_files_fail(self, mock_process):
+        """If every file for a DataTableID fails to parse, get_data raises ValueError."""
+        mock_process.side_effect = RuntimeError("boom")
+        with pytest.raises(ValueError, match="None of the"):
+            self.ds.get_data(dataTableIDs=[self.dt_id])
+
+    @patch.object(NOAADataset, "_process_file")
+    def test_get_data_keeps_every_file_that_succeeds(self, mock_process):
+        """
+        Different files under the same DataTableID can hold genuinely different
+        data (e.g. a tree-ring DataTableID bundling separate "Raw Measurements"
+        and "Chronology" files) rather than the same table in another format, so
+        get_data must not stop after the first successful file.
+        """
+        mock_process.side_effect = lambda url, mapping=None: [pd.DataFrame({"url": [url]})]
+
+        result = self.ds.get_data(dataTableIDs=[self.dt_id])
+        assert len(result) == 2  # both files parsed successfully; both are kept
+
+
+# ---------------------------------------------------------------------------
+# Tests: duplicate DataTableIDs across Study/Site pairs
+# ---------------------------------------------------------------------------
+
+class TestNOAADatasetDuplicateDataTableIDs:
+
+    def setup_method(self):
+        self.ds = NOAADataset()
+        self.mock_data = get_mock_study_response()
+        self.ds._parse_response(self.mock_data, limit=100)
+
+        # Force a collision: point a second Study/Site's PaleoData at the SAME
+        # DataTableID already used by a different Study/Site.
+        studies = list(self.ds.studies.values())
+        first_paleo = studies[0].sites[0].paleo_data[0]
+        self.dup_id = first_paleo.datatable_id
+        second_paleo = studies[1].sites[0].paleo_data[0]
+        second_paleo.datatable_id = self.dup_id
+        self.ds._reindex()
+
+    def test_get_tables_warns_on_duplicate(self, caplog):
+        with caplog.at_level("WARNING"):
+            self.ds.get_tables()
+        assert any(
+            "Duplicate DataTableID" in record.message and str(self.dup_id) in record.message
+            for record in caplog.records
+        )
+
+    @patch.object(NOAADataset, "_process_file")
+    def test_get_data_opens_files_from_every_colliding_entry(self, mock_process, caplog):
+        """Colliding entries are all attempted (not just the one left in the single-entry index)."""
+        mock_process.side_effect = lambda url, mapping=None: [pd.DataFrame({"url": [url]})]
+
+        with caplog.at_level("WARNING"):
+            result = self.ds.get_data(dataTableIDs=[self.dup_id])
+
+        assert any("Duplicate DataTableID" in record.message for record in caplog.records)
+        assert len(result) == 2  # one per colliding Study/Site
+
+
+# ---------------------------------------------------------------------------
+# Tests: .csv files and web page / directory-listing link extraction
+# ---------------------------------------------------------------------------
+
+class TestNOAADatasetCsvAndWebpage:
+
+    def setup_method(self):
+        self.ds = NOAADataset()
+
+    @patch("pandas.read_csv")
+    def test_process_csv_file(self, mock_read_csv):
+        mock_read_csv.return_value = pd.DataFrame({"a": [1, 2]})
+        result = self.ds._process_file("https://example.com/data.csv")
+        assert len(result) == 1
+        assert isinstance(result[0], pd.DataFrame)
+
+    def test_extract_links_from_html(self):
+        html = """
+        <html><body>
+        <a href="..">Parent Directory</a>
+        <a href="study.txt">study.txt</a>
+        <a href="study.csv">study.csv</a>
+        <a href="mailto:test@example.com">email</a>
+        </body></html>
+        """
+        links = self.ds._extract_links_from_html("https://example.com/folder/", html)
+        assert links == [
+            "https://example.com/folder/study.txt",
+            "https://example.com/folder/study.csv",
+        ]
+
+    @patch.object(NOAADataset, "_process_file")
+    def test_process_folder_page_tries_links_in_priority_order(self, mock_process):
+        html = """
+        <a href="data.csv">csv</a>
+        <a href="data-noaa.txt">txt</a>
+        """
+
+        def side_effect(url, mapping=None):
+            if url.endswith("noaa.txt"):
+                return [pd.DataFrame({"x": [1]})]
+            raise RuntimeError("nope")
+
+        mock_process.side_effect = side_effect
+        result = self.ds._process_folder_page("https://example.com/folder/", html)
+        assert len(result) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #58 

## Problem

`NOAADataset.get_data()` assumed a 1:1 mapping between DataTableID and file URL — it only ever fetched paleo_data.file_url, a shortcut to the first file NOAA attached to that table, silently ignoring the rest. In practice, one DataTableID can carry several files of different formats (a NOAA-templated .txt, the original contributed .txt, a .csv, a directory-listing page, or proprietary tree-ring formats), and these aren't always the same table in another format — e.g. a tree-ring DataTableID can bundle a separate "Raw Measurements" table and a "Chronology" table under one ID. The old code returned at most one of them, and would outright crash if the first-listed file happened to be a non-.txt link (e.g. a folder).

Separately, DataTableIDs were assumed unique; if the same ID ever appeared under two different Study/Site pairs, the internal index silently kept only the last one.

## Fix

1. `pyleotups/core/NOAADataset.py`

`get_data(dataTableIDs=...)` now attempts every file under a DataTableID, ranked easiest-first (NOAA structured .txt → Original Contributed .txt → .csv → web page/folder link via new `_rank_file_priority()`), and keeps a DataFrame for every file that parses instead of stopping at the first success. A failing file is logged and skipped rather than aborting the rest; it only raises if none of a table's files could be parsed.

`Duplicate DataTableIDs `(same ID across different Study/Site pairs) are now surfaced via `_check_duplicate_datatable_ids()`, called from both `get_tables()` and `get_data()`. A new `data_table_index_all multi-map lets get_data()` open files from every colliding Study/Site rather than only the one left in the old single-entry index.

`_process_file()` gains support for .csv (via pandas.read_csv) and for web pages / directory-listing links (no extension or .html): it fetches the page, extracts <a href> links with the stdlib html.parser (no new dependency), ranks them by the same priority, and attempts each — addressing the optional "detect folder, extract URLs" ask.

Proprietary tree-ring formats (.crn, .rwl, .fhx, .lpd) remain explicitly unsupported and are still rejected, just now as one skipped attempt among several rather than a hard stop.

2. `pyleotups/tests/test_NOAADataset.py`

New tests covering: priority ranking, falling back to the next file when the easiest one fails, raising when all files fail, keeping every DataFrame when multiple files succeed, duplicate-ID warnings in `get_tables()`/`get_data()`, opening files from every colliding Study/Site, .csv parsing, and folder-page link extraction/parsing.

Updated one existing assertion (test_get_data_t05_unsupported_file_type_raises) to match the more general "unsupported file type" message now that .csv and web pages are supported types.

## Verification
Full suite: 121 passed (117 pre-existing + new tests), no regressions.

Checked against the live NOAA API, not just mocks:
NOAAStudyId=6400: 3 DataTableIDs each with a folder-link + an alternate .txt. Old code crashed on the very first ID (folder link has no .txt extension); fixed code returns all 3 successfully. This study was also added to the tutorials as an example. 

xmlId=6400 (tree-ring study, DataTableID 6773, 5 files): now correctly returns 2 DataFrames (Chronology + Raw Measurements, the two NOAA-template .txt files) while clearly warning and skipping the 3 genuinely unparseable files (a prose correlation-stats report, .crn, .rwl).

## Use of AI

The fix was generated by Claude (including new test suites). Human reviewed the verification against NOAA API manually. 

