### PR TITLE
Update to new Pangaeapy version

### DIFF
--- a/pyleotups/utils/PangaeaStudy.py
+++ b/pyleotups/utils/PangaeaStudy.py
@@ -114,6 +114,24 @@ class PangaeaStudy:
 
         return df
 
+    def _iter_events(self):
+        """
+        Iterate over this dataset's `PanEvent` objects.
+
+        pangaeapy changed the shape of `PanDataSet.events` between versions:
+        older releases exposed it as a list of `PanEvent` objects, while newer
+        releases (>=1.1) expose it as a dict of ``{eventLabel: PanEvent}``.
+        Support both so pyleotups doesn't break on the installed version.
+
+        Returns
+        -------
+        Iterable of PanEvent
+        """
+        events = self._panobj.events
+        if isinstance(events, dict):
+            return events.values()
+        return events
+
     # ------------------------------------------------------------------
     # Summary Metadata
     # ------------------------------------------------------------------
@@ -270,7 +288,7 @@ class PangaeaStudy:
         latitudes = []
         longitudes = []
 
-        for ev in self._panobj.events:
+        for ev in self._iter_events():
             lat1 = ev.latitude
             lat2 = ev.latitude2 if getattr(ev, "latitude2", None) is not None else lat1
             lon1 = ev.longitude
@@ -322,7 +340,7 @@ class PangaeaStudy:
             "ScienceKeywords": getattr(ds, "keywords", None),
             "Investigators": ", ".join(a.fullname for a in ds.authors),
             "Publications": ds.citation,
-            "Sites": [e.label for e in ds.events],
+            "Sites": [e.label for e in self._iter_events()],
             "Funding": [
                 {"name": p.name, "url": p.URL, "award": p.awardURI}
                 for p in ds.projects
@@ -348,7 +366,7 @@ class PangaeaStudy:
             DataFrame containing event-level geographic information.
         """
         rows = []
-        for ev in self._panobj.events:
+        for ev in self._iter_events():
             lat1 = ev.latitude
             lon1 = ev.longitude
             lat2 = ev.latitude2 if getattr(ev, "latitude2", None) is not None else lat1


### PR DESCRIPTION

`pangaeapy 1.1.2` changed `PanDataSet.events` from a list of PanEvent objects to a dict of `{eventLabel: PanEvent}`. Every place in pyleotups that did for ev in `self._panobj.events`: was now iterating over dict keys (plain strings) instead of PanEvent objects, so `ev.latitude` blew up with `AttributeError: 'str' object has no attribute 'latitude'`. That one change cascaded into `_compute_coverage()`, `get_geo()`, and the "Sites" field of `to_summary_dict()` — which is why `search_studies()`, `get_summary()`, `get_geo()`, `get_variables()`, `get_funding()`, and `get_publications()` all failed (they all end up calling `to_summary_dict()`).

## Fix

Added `PangaeaStudy._iter_events()` — a small compatibility shim that returns events.values() if events is a dict, else events itself — and routed the three call sites through it instead of touching `self._panobj.events` directly. This keeps pyleotups working against both the old list-shaped and new dict-shaped events, so it won't silently break again if the pin drifts either direction.

## Verified

pyleotups/tests/test_PangaeaDataset.py: 10/10 pass (was 0/10)
Full suite: 121/121 pass, no regressions elsewhere
Confirmed no other .events usage in the codebase bypasses the new helper
No other pangaeapy API shapes (params, projects, relations, supplement_to, collection_members, isCollection, abstract/title/doi/keywords properties) appear to have changed — all those tests were passing already and stayed green.

Manually tested on the tutorials. 


## AI Use

Fix was made by Claude. Manually checked on the tutorials to ensure proper working conditions. 